### PR TITLE
Only show <pre> scrollbar when necessary

### DIFF
--- a/content/styles/main.css
+++ b/content/styles/main.css
@@ -253,7 +253,7 @@ p.metadata + h1.big-title {
 
 pre {
   max-height: 50vh;
-  overflow-y: scroll;
+  overflow-y: auto;
   background-color: #2d2d2d;
   color: #ccc;
   padding: 1em;


### PR DESCRIPTION
Only show `<pre>` scrollbar when necessary. In Chrome (latest macOS and Windows) scrollbars currently show **even when the code doesn't overflow**.


Before:

![scrollbar showing](https://user-images.githubusercontent.com/34559231/134006616-19c69adf-9e68-415e-b7cd-9bc5f78ab3a1.png)

After:
![scrollbar not showing](https://user-images.githubusercontent.com/34559231/134006621-fcb90dc7-e92b-4e71-a922-fc09b94e6372.png)

## Docs

https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-y#values

## QA Steps

This page: `/blog/2020/cmd-line-applications-appkit/` has overflowing and non-overflowing `<pre>` sections.

Check that they both appear normally on target platforms.